### PR TITLE
Mercury and Gemini View selector typo fixes

### DIFF
--- a/Gemini/GeminiGame/GeminiGame.en-us.json
+++ b/Gemini/GeminiGame/GeminiGame.en-us.json
@@ -77,11 +77,11 @@
   },
   {
     "Identifier": "ViewSelector_CommandersSeat",
-    "Text": "COMMANDERS SEAT"
+    "Text": "COMMANDER'S SEAT"
   },
   {
     "Identifier": "ViewSelector_CommanderPanel",
-    "Text": "COMMANDERS PANEL"
+    "Text": "COMMANDER'S PANEL"
   },
   {
     "Identifier": "ViewSelector_CenterPanel",

--- a/Mercury/MercuryGame/MercuryGame.en-us.json
+++ b/Mercury/MercuryGame/MercuryGame.en-us.json
@@ -1,7 +1,7 @@
 [
   {
     "Identifier": "ViewSelector_CommandersSeat",
-    "Text": "COMMANDERS SEAT"
+    "Text": "COMMANDER'S SEAT"
   },
   {
     "Identifier": "ViewSelector_LeftPanels",


### PR DESCRIPTION
Small change in both to ensure we put apostrophe's (') for all possessives in the View Selectors